### PR TITLE
Bugfix: Inserted link is now correct

### DIFF
--- a/js/eexcess-jquery-eventhandlers.js
+++ b/js/eexcess-jquery-eventhandlers.js
@@ -53,8 +53,8 @@ $j(document).ready(function() {
 
    // Handles the "add" buttons in the recommendation area
    $j(document).on("mousedown", 'input[name="addMatch"]', function(){
-      var url = $j($j("input[name='addMatch']")[0]).siblings("a").attr('href');
-      var title = $j($j("input[name='addMatch']")[0]).siblings("a").text();
+      var url =  $j(this).siblings("a").attr('href');
+      var title = $j(this).siblings("a").text();
       var cursorPosition = "";
       var text = "";
       if(tinyMCE.activeEditor && tinyMCE.activeEditor.isHidden() == false) {

--- a/js/eexcess-script.js
+++ b/js/eexcess-script.js
@@ -292,7 +292,7 @@ var EEXCESS_METHODS = function () {
          var template = Handlebars.compile($j("#list-template").html());
          var list = $j(template(o));
 
-         // image resizing to fit the design
+         // image resizing to fit the layout
          width = EEXCESS.recommendationListSettings.imageWidth;
          height = EEXCESS.recommendationListSettings.imageHeight;
          $j(list).find("img").each(function(index){


### PR DESCRIPTION
There was a bug in the functions that adds a hyperlink into the
textarea. No matter which "add"-button was pressed, always the first
link was inserted.
